### PR TITLE
feat: add Docker Compose watch configuration for hot-reload dev workflow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,16 @@ services:
       - PORT=8080
     depends_on:
       - redis
+    develop:
+      watch:
+        - path: ./cmd
+          action: rebuild
+        - path: ./internal
+          action: rebuild
+        - path: ./go.mod
+          action: rebuild
+        - path: ./go.sum
+          action: rebuild
+        - path: ./sdk/js
+          target: /app/sdk/js
+          action: sync


### PR DESCRIPTION
## Summary
Adds a `develop.watch` block to the `orbit` service in `docker-compose.yml`, enabling hot-reload during local development via Docker Compose Watch.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other (describe):

## Changes
- Added `develop.watch` config to the `orbit` service in `docker-compose.yml`
- Changes to `cmd/`, `internal/`, `go.mod`, or `go.sum` trigger a full container **rebuild**
- Changes to `sdk/js/` are **synced** into the container instantly without a rebuild

## Testing
- [ ] Ran `go vet ./...`
- [ ] Ran integration tests (`node tests/ws-pubsub.test.js`, `node tests/sdk-presence.test.js`)
- [x] Manually tested against a running server
- [ ] Added new tests (if applicable)

## Related Issues
NA

## Notes for reviewer
Run with: `docker-compose up --build --watch`
Requires Docker Desktop 4.24+ or Docker Engine with Compose v2.22+. No changes to runtime behavior — watch config is development-only.