### PR TITLE
docs: add product roadmap and align agents + PR template to phases

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Report a bug or unexpected behavior
-title: "fix: "
+title: "[Bug] "
 labels: bug
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Report a bug or unexpected behavior
-title: "[Bug] "
+title: "fix: "
 labels: bug
 assignees: ''
 ---
@@ -25,7 +25,12 @@ What actually happened. Include error messages or logs if available.
 - OS: [e.g. Ubuntu 22.04, macOS 14]
 - Go version: [e.g. 1.23]
 - Redis version: [e.g. 7.2]
+- Orbit version / commit:
 - Deployment: [Docker / local binary]
+
+## Logs
+```
+```
 
 ## Additional context
 Any other context, screenshots, or configuration details.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/JabezSanjay/orbit/security/advisories/new
+    about: Please report security vulnerabilities privately via GitHub Security Advisories — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,14 @@ labels: enhancement
 assignees: ''
 ---
 
+## Roadmap phase
+<!-- Which phase does this belong to? See AGENTS.md for the full roadmap. -->
+- [ ] Phase 1 — Stable Alpha (security + correctness)
+- [ ] Phase 2 — Public Beta (production-readiness)
+- [ ] Phase 3 — v1.0 (developer experience)
+- [ ] Phase 4 — Ecosystem (platform features)
+- [ ] Not on roadmap yet
+
 ## Problem / Motivation
 What problem does this solve? What's missing today?
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,18 @@
+<!-- Roadmap phases:
+  Phase 1 — Stable Alpha: auth, ACLs, security fixes
+  Phase 2 — Public Beta: message history, namespaces, SDKs, rate limiting
+  Phase 3 — v1.0: admin UI, Docker Hub, Helm chart, structured logging
+  Phase 4 — Ecosystem: REST API, webhooks, SSE fallback, multi-tenant
+-->
+
+## Phase
+<!-- Which roadmap phase does this PR belong to? -->
+- [ ] Phase 1 — Stable Alpha
+- [ ] Phase 2 — Public Beta
+- [ ] Phase 3 — v1.0
+- [ ] Phase 4 — Ecosystem
+- [ ] None / cross-cutting
+
 ## Summary
 <!-- What does this PR do? One or two sentences. -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,7 +289,7 @@ Stress-tests the Redis PubSub engine directly (no WebSocket layer):
 
 ---
 
-## Known Limitations / Future Work
+## Known Limitations
 
 - **Auth is a stub**: Replace `TokenAuthenticator` with JWT decoding or HMAC verification
 - **`InsecureSkipVerify: true`** must be removed before production deployment
@@ -298,3 +298,48 @@ Stress-tests the Redis PubSub engine directly (no WebSocket layer):
 - **Hardcoded secret** `"secret"` in server startup
 - No TLS termination in binary; expected to be handled by a reverse proxy (nginx, Caddy)
 - No unsubscribe message sent to server from JS SDK on `unsubscribe()` call (local cleanup only)
+
+---
+
+## Roadmap
+
+Orbit ships in four phases. All agents and contributors working on this project **must align work to a phase** before implementing features.
+
+### Phase 1 — Stable Alpha *(security + correctness)*
+> Blockers before any public deployment.
+
+- [ ] Replace auth stub with real JWT / HMAC token validation
+- [ ] Remove `InsecureSkipVerify` from WebSocket accept
+- [ ] Implement `CanSubscribe` / `CanPublish` channel-level ACLs
+- [ ] Fix JS SDK `unsubscribe()` to send an unsubscribe frame to the server
+- [ ] Harden CI: reliable server-ready health check before integration tests
+
+### Phase 2 — Public Beta *(production-readiness)*
+> Safe to run in real environments.
+
+- [ ] Message history + replay via Redis Streams (`XADD` / `XREAD`)
+- [ ] Per-namespace channel config (custom TTLs, ACL rules, history depth)
+- [ ] Connection rate limiting and per-user connection caps
+- [ ] TLS termination guide + example nginx / Caddy configs
+- [ ] Python SDK
+- [ ] Go client SDK
+
+### Phase 3 — v1.0 *(developer experience)*
+> Polished, well-documented, observable.
+
+- [ ] Read-only admin dashboard (active connections, channels, message rates)
+- [ ] Official Docker Hub image + versioned releases
+- [ ] Helm chart for Kubernetes deployments
+- [ ] Structured JSON logging with configurable log levels
+- [ ] Graceful shutdown with in-flight message draining
+
+### Phase 4 — Ecosystem *(platform features)*
+> Compete with hosted platforms on features, not just price.
+
+- [ ] REST publish API — publish to a channel over HTTP without a WebSocket connection
+- [ ] Webhooks — fire HTTP callbacks on publish / presence events
+- [ ] SSE fallback for clients that block WebSockets
+- [ ] Multi-tenant namespace isolation
+- [ ] Official Grafana dashboard (pre-built, importable)
+
+> **Scope guard:** Orbit is meant to be understandable in an afternoon. Features that require a config file longer than 50 lines belong in a different project. When in doubt, do less.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [Unreleased]
+
+### Phase 1 — Stable Alpha (upcoming)
+- JWT / HMAC token authentication replacing the current stub
+- Channel-level ACLs (`CanSubscribe` / `CanPublish`)
+- Remove `InsecureSkipVerify` from WebSocket accept
+- JS SDK server-side `unsubscribe` frame
+
+### Phase 2 — Public Beta (planned)
+- Message history and replay via Redis Streams
+- Per-namespace channel configuration (TTL, ACL, history depth)
+- Connection rate limiting and per-user caps
+- Python SDK and Go client SDK
+
+### Phase 3 — v1.0 (planned)
+- Read-only admin dashboard
+- Official Docker Hub image + versioned releases
+- Helm chart for Kubernetes
+- Structured JSON logging
+- Graceful shutdown with in-flight message draining
+
+### Phase 4 — Ecosystem (future)
+- REST publish API
+- Webhooks on publish / presence events
+- SSE fallback transport
+- Multi-tenant namespace isolation
+- Official Grafana dashboard
+
+---
+
 ## [0.1.0] — 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -180,6 +180,53 @@ The current release is an **MVP**. Before deploying to production:
 
 ---
 
+## Roadmap
+
+Orbit ships in four phases. The goal is to stay simple, not to become Centrifugo.
+
+### Phase 1 — Stable Alpha *(security + correctness)*
+> Fix every blocker before any public deployment.
+
+- [ ] Replace auth stub with real JWT / HMAC token validation
+- [ ] Remove `InsecureSkipVerify` from WebSocket accept
+- [ ] Implement `CanSubscribe` / `CanPublish` channel-level ACLs
+- [ ] Fix JS SDK `unsubscribe()` to send an unsubscribe frame to the server
+- [ ] Harden CI: reliable server-ready health check before integration tests
+
+### Phase 2 — Public Beta *(production-readiness)*
+> Safe to run in real environments.
+
+- [ ] Message history + replay via Redis Streams (`XADD` / `XREAD`)
+- [ ] Per-namespace channel config (custom TTLs, ACL rules, history depth)
+- [ ] Connection rate limiting and per-user connection caps
+- [ ] TLS termination guide + example nginx / Caddy configs
+- [ ] Python SDK
+- [ ] Go client SDK
+
+### Phase 3 — v1.0 *(developer experience)*
+> Polished, well-documented, observable.
+
+- [ ] Read-only admin dashboard (active connections, channels, message rates)
+- [ ] Official Docker Hub image + versioned releases
+- [ ] Helm chart for Kubernetes deployments
+- [ ] Structured JSON logging with configurable log levels
+- [ ] Graceful shutdown with in-flight message draining
+
+### Phase 4 — Ecosystem *(platform features)*
+> Compete with hosted platforms on features, not just on price.
+
+- [ ] REST publish API — publish to a channel over HTTP without a WebSocket connection
+- [ ] Webhooks — fire HTTP callbacks on publish / presence events
+- [ ] SSE fallback for clients that block WebSockets
+- [ ] Multi-tenant namespace isolation
+- [ ] Official Grafana dashboard (pre-built, importable)
+
+---
+
+> **Scope guard:** Orbit is meant to be understandable in an afternoon. Features that require a configuration file longer than 50 lines belong in a different project.
+
+---
+
 ## Contributing
 
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.


### PR DESCRIPTION
## Phase
- [ ] Phase 1 — Stable Alpha
- [ ] Phase 2 — Public Beta
- [ ] Phase 3 — v1.0
- [ ] Phase 4 — Ecosystem
- [x] None / cross-cutting

## Summary
Adds a four-phase product roadmap to README.md, CHANGELOG.md, and AGENTS.md. Updates the PR template so all future contributions declare which roadmap phase they belong to.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other (describe):

## Changes
- Added `## Roadmap` section to `README.md` with phase-by-phase checklist
- Added `[Unreleased]` roadmap block to `CHANGELOG.md`
- Replaced flat "Known Limitations" in `AGENTS.md` with the full phased roadmap — agents must now align work to a phase before implementing
- Added Phase selector to PR template so every PR is explicitly roadmap-aligned

## Testing
- [ ] Ran `go vet ./...`
- [ ] Ran integration tests (`node tests/ws-pubsub.test.js`, `node tests/sdk-presence.test.js`)
- [ ] Manually tested against a running server
- [ ] Added new tests (if applicable)

## Related Issues

## Notes for reviewer
No code changes — docs only. The key change is `AGENTS.md`: every agent and contributor working on this project is now instructed to pick a phase before writing any code.