### PR TITLE
feat: add support for allowed WebSocket origins and remove InsecureSkipVerify

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Each Orbit node holds a single multiplexed Redis PubSub connection. Messages are
 | `PORT` | `8080` | HTTP server listen port |
 | `REDIS_URL` | `redis://localhost:6379` | Redis connection URL |
 | `ORBIT_FANOUT_WORKERS` | `100` | Worker goroutines for Redis message dispatch |
+| `ORBIT_ALLOWED_ORIGINS` | _(same-origin only)_ | Comma-separated list of allowed WebSocket origins (e.g. `http://localhost:5173,https://myapp.com`) |
 
 ---
 
@@ -175,7 +176,6 @@ npm run dev
 The current release is an **MVP**. Before deploying to production:
 
 - **Auth is a stub** — `token` query param maps directly to a userID. Replace `TokenAuthenticator` in `internal/auth/auth.go` with real JWT or HMAC validation.
-- **`InsecureSkipVerify: true`** is set on WebSocket accept for local dev. Remove this for production.
 - **No TLS** — run behind a reverse proxy (nginx, Caddy) that handles HTTPS/WSS termination.
 
 ---

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/coder/websocket"
@@ -43,6 +44,16 @@ func main() {
 	}
 	redisClient := redis.NewClient(opts)
 
+	// Allowed origins for WebSocket upgrades (comma-separated)
+	var allowedOrigins []string
+	if raw := os.Getenv("ORBIT_ALLOWED_ORIGINS"); raw != "" {
+		for _, o := range strings.Split(raw, ",") {
+			if o = strings.TrimSpace(o); o != "" {
+				allowedOrigins = append(allowedOrigins, o)
+			}
+		}
+	}
+
 	// 2. Initialize Core Services
 	authenticator := auth.NewTokenAuthenticator("secret") // Stub Secret
 	tracker := presence.NewTracker(redisClient, 45*time.Second) // 45s TTL
@@ -63,7 +74,7 @@ func main() {
 		}
 
 		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-			InsecureSkipVerify: true, // For cross-origin dev testing
+			OriginPatterns: allowedOrigins,
 		})
 		if err != nil {
 			log.Printf("WS Upgrade Error: %v", err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379
       - PORT=8080
+      - ORBIT_ALLOWED_ORIGINS=http://localhost:5173
     depends_on:
       - redis
     develop:


### PR DESCRIPTION
## Version
<!-- Which roadmap version does this PR belong to? -->
- [x] v0.1 — Trustworthy (security + survivability)
- [ ] v0.2 — Differentiated (presence primitives)
- [ ] v0.3 — Adoption (developer onboarding)
- [ ] v0.5 — Observable (durable messaging + observability)
- [ ] v1.0 — Platform (ecosystem + resilience)
- [ ] None / cross-cutting

## Summary
<!-- What does this PR do? One or two sentences. -->
Removes InsecureSkipVerify from WebSocket accept. Cross-origin connections now require explicit allowlisting via ORBIT_ALLOWED_ORIGINS. Defaults to  same-origin only when unset.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other (describe):

## Changes
<!-- List the key changes made -->
- Removed `InsecureSkipVerify: true` from WebSocket accept options
- Added `ORBIT_ALLOWED_ORIGINS` env var (comma-separated allowlist); defaults to same-origin only
- Updated `docker-compose.yml` to set `http://localhost:5173` for the Vite dev server
- Updated README env table and removed stale security notice bullet

## Testing
<!-- How did you test this? -->
- [x] Ran `go vet ./...`
- [x] Ran integration tests (`node tests/ws-pubsub.test.js`, `node tests/sdk-presence.test.js`)
- [x] Manually tested against a running server
- [ ] Added new tests (if applicable)

## Related Issues
Closes #5 

## Notes for reviewer
<!-- Anything the reviewer should pay special attention to? -->
