### PR TITLE
fix: preserve Content-Type: application/json on error responses in /api/presence

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -97,16 +97,18 @@ func main() {
 	mux.HandleFunc("/api/presence", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Content-Type", "application/json")
-		
+
 		channel := r.URL.Query().Get("channel")
 		if channel == "" {
-			http.Error(w, `{"error":"missing channel parameter"}`, http.StatusBadRequest)
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"missing channel parameter"}`))
 			return
 		}
 
 		users, err := tracker.GetUsers(r.Context(), channel)
 		if err != nil {
-			http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"internal server error"}`))
 			return
 		}
 


### PR DESCRIPTION
## Version
- [x] v0.1 — Trustworthy (security + survivability)
- [ ] v0.2 — Differentiated (presence primitives)
- [ ] v0.3 — Adoption (developer onboarding)
- [ ] v0.5 — Observable (durable messaging + observability)
- [ ] v1.0 — Platform (ecosystem + resilience)
- [ ] None / cross-cutting

## Summary
`http.Error()` overwrites `Content-Type` to `text/plain`, so error responses from `/api/presence` returned the wrong content type. Replaced with manual `WriteHeader` + `Write` so all responses consistently return `application/json`.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other (describe):

## Changes
- Replaced `http.Error()` calls in `/api/presence` handler with manual `w.WriteHeader()` + `w.Write()`
- All responses (200, 400, 500) now return `Content-Type: application/json`

## Testing
- [x] Ran `go vet ./...`
- [ ] Ran integration tests (`node tests/ws-pubsub.test.js`, `node tests/sdk-presence.test.js`)
- [x] Manually tested against a running server
- [ ] Added new tests (if applicable)

## Related Issues
Closes #8

## Notes for reviewer
NA
