### PR TITLE
docs: record /api/presence Content-Type fix in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Channel-level ACLs (`CanSubscribe` / `CanPublish`)
 - ✅ Remove `InsecureSkipVerify` from WebSocket accept — replaced with `ORBIT_ALLOWED_ORIGINS` allowlist
 - ✅ Fix JS SDK `unsubscribe()` — now sends unsubscribe frame to server when last handler is removed
+- ✅ Fix `/api/presence` — all responses now return `Content-Type: application/json` (error paths were returning `text/plain`)
 - Connection rate limiting and per-user connection caps
 - Graceful shutdown with in-flight message draining
 - Slow consumer detection — per-connection outbound buffer limits and drop policy


### PR DESCRIPTION
## Version
- [ ] v0.1 — Trustworthy (security + survivability)
- [ ] v0.2 — Differentiated (presence primitives)
- [ ] v0.3 — Adoption (developer onboarding)
- [ ] v0.5 — Observable (durable messaging + observability)
- [ ] v1.0 — Platform (ecosystem + resilience)
- [x] None / cross-cutting

## Summary
Records the /api/presence Content-Type fix in CHANGELOG.md.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other (describe):

## Changes
<!-- List the key changes made -->
- Added ✅ entry for #8 (`/api/presence` Content-Type fix) to CHANGELOG.md

## Testing
- [ ] Ran `go vet ./...`
- [ ] Ran integration tests (`node tests/ws-pubsub.test.js`, `node tests/sdk-presence.test.js`)
- [ ] Manually tested against a running server
- [ ] Added new tests (if applicable)

## Related Issues
<!-- none — #8 was already merged -->

## Notes for reviewer
<!-- Anything the reviewer should pay special attention to? -->
