### PR TITLE
feat: replace auth stub with JWT HS256 validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,14 @@ jobs:
         env:
           PORT: 8080
           REDIS_URL: redis://localhost:6379
+          ORBIT_JWT_SECRET: orbit-ci-test-secret-do-not-use-in-production
 
       - name: Run integration test (raw WebSocket)
         run: node tests/ws-pubsub.test.js
+        env:
+          ORBIT_JWT_SECRET: orbit-ci-test-secret-do-not-use-in-production
 
       - name: Run integration test (Orbit SDK)
         run: node tests/sdk-presence.test.js
+        env:
+          ORBIT_JWT_SECRET: orbit-ci-test-secret-do-not-use-in-production

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Each Orbit node holds a single multiplexed Redis PubSub connection. Messages are
 | `REDIS_URL` | `redis://localhost:6379` | Redis connection URL |
 | `ORBIT_FANOUT_WORKERS` | `100` | Worker goroutines for Redis message dispatch |
 | `ORBIT_ALLOWED_ORIGINS` | _(same-origin only)_ | Comma-separated list of allowed WebSocket origins (e.g. `http://localhost:5173,https://myapp.com`) |
+| `ORBIT_JWT_SECRET` | _(required)_ | HS256 signing secret — minimum 32 characters. Server refuses to start if unset or too short. |
 
 ---
 
@@ -175,7 +176,8 @@ npm run dev
 
 The current release is an **MVP**. Before deploying to production:
 
-- **Auth is a stub** — `token` query param maps directly to a userID. Replace `TokenAuthenticator` in `internal/auth/auth.go` with real JWT or HMAC validation.
+- **Set a strong `ORBIT_JWT_SECRET`** — minimum 32 characters, generated randomly (e.g. `openssl rand -hex 32`). The server refuses to start without it.
+- **Issue short-lived JWTs** — set `exp` to 1 hour or less from your backend. Orbit enforces expiry on every connection.
 - **No TLS** — run behind a reverse proxy (nginx, Caddy) that handles HTTPS/WSS termination.
 
 ---

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -30,6 +30,11 @@ func main() {
 		redisURL = "redis://localhost:6379"
 	}
 
+	jwtSecret := os.Getenv("ORBIT_JWT_SECRET")
+	if len(jwtSecret) < 32 {
+		log.Fatal("ORBIT_JWT_SECRET must be set and at least 32 characters long")
+	}
+
 	// 1. Initialize Redis Engine
 	pubsubEngine, err := pubsub.NewRedisEngine(redisURL)
 	if err != nil {
@@ -55,7 +60,7 @@ func main() {
 	}
 
 	// 2. Initialize Core Services
-	authenticator := auth.NewTokenAuthenticator("secret") // Stub Secret
+	authenticator := auth.NewJWTAuthenticator(jwtSecret)
 	tracker := presence.NewTracker(redisClient, 45*time.Second) // 45s TTL
 	
 	gateway := ws.NewGateway()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - REDIS_URL=redis://redis:6379
       - PORT=8080
       - ORBIT_ALLOWED_ORIGINS=http://localhost:5173
+      - ORBIT_JWT_SECRET=orbit-local-dev-secret-do-not-use-in-production
     depends_on:
       - redis
     develop:

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"errors"
 	"net/http"
+	"strings"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 var ErrUnauthorized = errors.New("unauthorized")
@@ -14,34 +16,60 @@ type Authenticator interface {
 	CanPublish(userID, channel string) bool
 }
 
-// TokenAuthenticator is a basic authenticator that checks for a 'token' query param.
-// In a real system, you'd decode a JWT or verify against an auth service.
-type TokenAuthenticator struct {
-	secret string // Example for future extension
+// JWTAuthenticator validates HS256-signed JWTs.
+// The token must contain a non-empty "sub" claim and must not be expired.
+// Token is read from Authorization: Bearer header first, then ?token= query param.
+type JWTAuthenticator struct {
+	secret []byte
 }
 
-func NewTokenAuthenticator(secret string) *TokenAuthenticator {
-	return &TokenAuthenticator{secret: secret}
+// NewJWTAuthenticator creates a JWTAuthenticator.
+// secret must be at least 32 bytes; callers should enforce this before calling.
+func NewJWTAuthenticator(secret string) *JWTAuthenticator {
+	return &JWTAuthenticator{secret: []byte(secret)}
 }
 
-func (a *TokenAuthenticator) Authenticate(r *http.Request) (string, error) {
-	token := r.URL.Query().Get("token")
-	if token == "" {
-		// MVP: If no token, return empty string, let's treat them as anonymous.
-		return "anonymous", nil
+func (a *JWTAuthenticator) Authenticate(r *http.Request) (string, error) {
+	raw := extractToken(r)
+	if raw == "" {
+		return "", ErrUnauthorized
 	}
-	
-	// Mock validation: In reality, decode and map to a userID
-	userID := "user_" + token
-	return userID, nil
+
+	token, err := jwt.Parse(raw, func(t *jwt.Token) (interface{}, error) {
+		// Reject any algorithm that is not HS256 — prevents alg:none and RS/ES attacks
+		if t.Method != jwt.SigningMethodHS256 {
+			return nil, ErrUnauthorized
+		}
+		return a.secret, nil
+	}, jwt.WithValidMethods([]string{"HS256"}), jwt.WithExpirationRequired())
+
+	if err != nil || !token.Valid {
+		return "", ErrUnauthorized
+	}
+
+	sub, err := token.Claims.GetSubject()
+	if err != nil || sub == "" {
+		return "", ErrUnauthorized
+	}
+
+	return sub, nil
 }
 
-func (a *TokenAuthenticator) CanSubscribe(userID, channel string) bool {
-	// MVP: Everyone can subscribe to everything
-	return true
+func (a *JWTAuthenticator) CanSubscribe(userID, channel string) bool {
+	return true // Channel-level ACLs implemented in #6
 }
 
-func (a *TokenAuthenticator) CanPublish(userID, channel string) bool {
-	// MVP: Everyone can publish to everything
-	return true
+func (a *JWTAuthenticator) CanPublish(userID, channel string) bool {
+	return true // Channel-level ACLs implemented in #6
+}
+
+// extractToken returns the raw JWT string from the request.
+// Checks Authorization: Bearer header first, then ?token= query param.
+func extractToken(r *http.Request) string {
+	if header := r.Header.Get("Authorization"); header != "" {
+		if strings.HasPrefix(header, "Bearer ") {
+			return strings.TrimPrefix(header, "Bearer ")
+		}
+	}
+	return r.URL.Query().Get("token")
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,146 @@
   "packages": {
     "": {
       "dependencies": {
+        "jsonwebtoken": "^9.0.3",
         "ws": "^8.20.0"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "jsonwebtoken": "^9.0.3",
     "ws": "^8.20.0"
   }
 }

--- a/tests/sdk-presence.test.js
+++ b/tests/sdk-presence.test.js
@@ -1,7 +1,12 @@
 const { Orbit } = require('../example/src/orbit.js');
+const jwt = require('jsonwebtoken');
 // Quick adaptation for node:
 global.WebSocket = require('ws');
-const orbit = new Orbit('ws://localhost:8080/ws?token=test');
+
+const SECRET = process.env.ORBIT_JWT_SECRET || 'orbit-local-dev-secret-do-not-use-in-production';
+const token = jwt.sign({ sub: 'testuser' }, SECRET, { algorithm: 'HS256', expiresIn: '1h' });
+
+const orbit = new Orbit(`ws://localhost:8080/ws?token=${token}`);
 orbit.onConnected(() => {
     orbit.subscribe('global-hub', (msg) => {
         console.log("MSG EVENT:", msg.event);

--- a/tests/ws-pubsub.test.js
+++ b/tests/ws-pubsub.test.js
@@ -1,7 +1,10 @@
-const fs = require('fs');
 const WebSocket = require('ws');
+const jwt = require('jsonwebtoken');
 
-const ws = new WebSocket('ws://localhost:8080/ws?token=testuser');
+const SECRET = process.env.ORBIT_JWT_SECRET || 'orbit-local-dev-secret-do-not-use-in-production';
+const token = jwt.sign({ sub: 'testuser' }, SECRET, { algorithm: 'HS256', expiresIn: '1h' });
+
+const ws = new WebSocket(`ws://localhost:8080/ws?token=${token}`);
 
 ws.on('open', () => {
   ws.send(JSON.stringify({ type: 'subscribe', channel: 'room-1' }));


### PR DESCRIPTION
## Version
<!-- Which roadmap version does this PR belong to? -->
- [x] v0.1 — Trustworthy (security + survivability)
- [ ] v0.2 — Differentiated (presence primitives)
- [ ] v0.3 — Adoption (developer onboarding)
- [ ] v0.5 — Observable (durable messaging + observability)
- [ ] v1.0 — Platform (ecosystem + resilience)
- [ ] None / cross-cutting

## Summary
- Replace auth stub with JWT HS256 validation

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other (describe):

## Changes
- Add JWTAuthenticator: validates HS256 tokens, enforces exp claim, rejects alg:none and non-HS256 tokens, extracts sub as userID
- Token read from Authorization: Bearer header, fallback to ?token= param
- Anonymous connections rejected (empty/missing token → 401)
- ORBIT_JWT_SECRET env var required; server fatal if < 32 chars
- Dev secret added to docker-compose.yml
- Remove hardcoded 'secret' from codebase

## Testing
<!-- How did you test this? -->
- [x] Ran `go vet ./...`
- [x] Ran integration tests (`node tests/ws-pubsub.test.js`, `node tests/sdk-presence.test.js`)
- [x] Manually tested against a running server
- [ ] Added new tests (if applicable)

## Related Issues
Closes #4 

## Notes for reviewer
