### PR TITLE
feat: implement channel-level ACLs for subscription and publishing permissions

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -66,13 +66,13 @@ func main() {
 	gateway := ws.NewGateway()
 	go gateway.Run()
 
-	msgRouter := router.NewDefaultRouter(authenticator, pubsubEngine, tracker, gateway)
+	msgRouter := router.NewDefaultRouter(pubsubEngine, tracker, gateway)
 
 	// 3. HTTP Handlers
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
-		userID, err := authenticator.Authenticate(r)
+		userID, perms, err := authenticator.Authenticate(r)
 		if err != nil {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
@@ -87,7 +87,7 @@ func main() {
 		}
 
 		id := uuid.New().String()
-		client := ws.NewClient(id, userID, conn, gateway, msgRouter)
+		client := ws.NewClient(id, userID, perms, conn, gateway, msgRouter)
 		
 		gateway.Register <- client
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -4,21 +4,76 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+
 	"github.com/golang-jwt/jwt/v5"
 )
 
 var ErrUnauthorized = errors.New("unauthorized")
 
-// Authenticator validates connections and provides channel-level access control.
+// ChannelPermissions holds the channel patterns a connection is allowed to use.
+// Parsed from the JWT "channels" claim at connect time and stored on the Client.
+// An empty slice means no access. Use ["*"] to allow all channels.
+type ChannelPermissions struct {
+	Subscribe []string
+	Publish   []string
+}
+
+// CanSubscribe returns true if the given channel matches any pattern in perms.Subscribe.
+func CanSubscribe(perms *ChannelPermissions, channel string) bool {
+	if perms == nil {
+		return false
+	}
+	return matchAny(perms.Subscribe, channel)
+}
+
+// CanPublish returns true if the given channel matches any pattern in perms.Publish.
+func CanPublish(perms *ChannelPermissions, channel string) bool {
+	if perms == nil {
+		return false
+	}
+	return matchAny(perms.Publish, channel)
+}
+
+// matchAny returns true if channel matches at least one pattern.
+// Supports a single trailing wildcard: "room-*" matches "room-anything".
+// "*" alone matches any channel.
+func matchAny(patterns []string, channel string) bool {
+	for _, p := range patterns {
+		if p == "*" {
+			return true
+		}
+		if strings.HasSuffix(p, "*") {
+			if strings.HasPrefix(channel, p[:len(p)-1]) {
+				return true
+			}
+		} else if p == channel {
+			return true
+		}
+	}
+	return false
+}
+
+// Authenticator validates connections and returns the userID and channel permissions.
 type Authenticator interface {
-	Authenticate(r *http.Request) (string, error)
-	CanSubscribe(userID, channel string) bool
-	CanPublish(userID, channel string) bool
+	Authenticate(r *http.Request) (userID string, perms *ChannelPermissions, err error)
 }
 
 // JWTAuthenticator validates HS256-signed JWTs.
 // The token must contain a non-empty "sub" claim and must not be expired.
 // Token is read from Authorization: Bearer header first, then ?token= query param.
+// Channel permissions are read from the "channels" claim:
+//
+//	{
+//	  "sub": "user123",
+//	  "exp": 1234567890,
+//	  "channels": {
+//	    "subscribe": ["room-*", "notifications-user123"],
+//	    "publish":   ["room-1"]
+//	  }
+//	}
+//
+// If the "channels" claim is absent or either list is empty, access is denied (deny by default).
+// Use ["*"] to allow all channels.
 type JWTAuthenticator struct {
 	secret []byte
 }
@@ -29,14 +84,13 @@ func NewJWTAuthenticator(secret string) *JWTAuthenticator {
 	return &JWTAuthenticator{secret: []byte(secret)}
 }
 
-func (a *JWTAuthenticator) Authenticate(r *http.Request) (string, error) {
+func (a *JWTAuthenticator) Authenticate(r *http.Request) (string, *ChannelPermissions, error) {
 	raw := extractToken(r)
 	if raw == "" {
-		return "", ErrUnauthorized
+		return "", nil, ErrUnauthorized
 	}
 
 	token, err := jwt.Parse(raw, func(t *jwt.Token) (interface{}, error) {
-		// Reject any algorithm that is not HS256 — prevents alg:none and RS/ES attacks
 		if t.Method != jwt.SigningMethodHS256 {
 			return nil, ErrUnauthorized
 		}
@@ -44,27 +98,56 @@ func (a *JWTAuthenticator) Authenticate(r *http.Request) (string, error) {
 	}, jwt.WithValidMethods([]string{"HS256"}), jwt.WithExpirationRequired())
 
 	if err != nil || !token.Valid {
-		return "", ErrUnauthorized
+		return "", nil, ErrUnauthorized
 	}
 
-	sub, err := token.Claims.GetSubject()
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return "", nil, ErrUnauthorized
+	}
+
+	sub, err := claims.GetSubject()
 	if err != nil || sub == "" {
-		return "", ErrUnauthorized
+		return "", nil, ErrUnauthorized
 	}
 
-	return sub, nil
+	perms := parseChannelPermissions(claims)
+	return sub, perms, nil
 }
 
-func (a *JWTAuthenticator) CanSubscribe(userID, channel string) bool {
-	return true // Channel-level ACLs implemented in #6
+func parseChannelPermissions(claims jwt.MapClaims) *ChannelPermissions {
+	perms := &ChannelPermissions{}
+	channelsClaim, ok := claims["channels"]
+	if !ok {
+		return perms
+	}
+	channelsMap, ok := channelsClaim.(map[string]interface{})
+	if !ok {
+		return perms
+	}
+	perms.Subscribe = extractStringSlice(channelsMap, "subscribe")
+	perms.Publish = extractStringSlice(channelsMap, "publish")
+	return perms
 }
 
-func (a *JWTAuthenticator) CanPublish(userID, channel string) bool {
-	return true // Channel-level ACLs implemented in #6
+func extractStringSlice(m map[string]interface{}, key string) []string {
+	raw, ok := m[key]
+	if !ok {
+		return nil
+	}
+	items, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if s, ok := item.(string); ok && s != "" {
+			result = append(result, s)
+		}
+	}
+	return result
 }
 
-// extractToken returns the raw JWT string from the request.
-// Checks Authorization: Bearer header first, then ?token= query param.
 func extractToken(r *http.Request) string {
 	if header := r.Header.Get("Authorization"); header != "" {
 		if strings.HasPrefix(header, "Bearer ") {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -19,7 +19,6 @@ type RouterMetrics struct {
 }
 
 type DefaultRouter struct {
-	auth     auth.Authenticator
 	pubsub   pubsub.Engine
 	presence *presence.Tracker
 	gateway  *ws.Gateway
@@ -30,9 +29,8 @@ type DefaultRouter struct {
 	subscriptions map[string]map[*ws.Client]bool
 }
 
-func NewDefaultRouter(a auth.Authenticator, p pubsub.Engine, pr *presence.Tracker, g *ws.Gateway) *DefaultRouter {
+func NewDefaultRouter(p pubsub.Engine, pr *presence.Tracker, g *ws.Gateway) *DefaultRouter {
 	return &DefaultRouter{
-		auth:          a,
 		pubsub:        p,
 		presence:      pr,
 		gateway:       g,
@@ -92,8 +90,8 @@ func (r *DefaultRouter) handleSubscribe(ctx context.Context, client *ws.Client, 
 		return
 	}
 
-	if !r.auth.CanSubscribe(client.UserID, channel) {
-		client.SendJSON(core.Envelope{Type: "error", Payload: json.RawMessage(`{"error":"unauthorized access to channel"}`)})
+	if !auth.CanSubscribe(client.Permissions, channel) {
+		client.SendJSON(core.Envelope{Type: "error", Payload: json.RawMessage(`{"error":"not authorized to subscribe to this channel"}`)})
 		return
 	}
 
@@ -128,7 +126,8 @@ func (r *DefaultRouter) handlePublish(ctx context.Context, client *ws.Client, ms
 		return
 	}
 
-	if !r.auth.CanPublish(client.UserID, msg.Channel) {
+	if !auth.CanPublish(client.Permissions, msg.Channel) {
+		client.SendJSON(core.Envelope{Type: "error", Payload: json.RawMessage(`{"error":"not authorized to publish to this channel"}`)})
 		return
 	}
 

--- a/internal/ws/client.go
+++ b/internal/ws/client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
+	"github.com/orbit/orbit/internal/auth"
 	"github.com/orbit/orbit/internal/core"
 )
 
@@ -22,10 +23,11 @@ type Router interface {
 
 // Client represents a single connected WebSocket user.
 type Client struct {
-	ID     string
-	UserID string
-	Conn   *websocket.Conn
-	Send   chan core.Envelope
+	ID          string
+	UserID      string
+	Permissions *auth.ChannelPermissions
+	Conn        *websocket.Conn
+	Send        chan core.Envelope
 
 	Gateway *Gateway
 	Router  Router
@@ -34,17 +36,18 @@ type Client struct {
 	cancelFunc context.CancelFunc
 }
 
-func NewClient(id, userID string, conn *websocket.Conn, gateway *Gateway, router Router) *Client {
+func NewClient(id, userID string, perms *auth.ChannelPermissions, conn *websocket.Conn, gateway *Gateway, router Router) *Client {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Client{
-		ID:         id,
-		UserID:     userID,
-		Conn:       conn,
-		Send:       make(chan core.Envelope, 256),
-		Gateway:    gateway,
-		Router:     router,
-		ctx:        ctx,
-		cancelFunc: cancel,
+		ID:          id,
+		UserID:      userID,
+		Permissions: perms,
+		Conn:        conn,
+		Send:        make(chan core.Envelope, 256),
+		Gateway:     gateway,
+		Router:      router,
+		ctx:         ctx,
+		cancelFunc:  cancel,
 	}
 }
 

--- a/tests/sdk-presence.test.js
+++ b/tests/sdk-presence.test.js
@@ -4,7 +4,11 @@ const jwt = require('jsonwebtoken');
 global.WebSocket = require('ws');
 
 const SECRET = process.env.ORBIT_JWT_SECRET || 'orbit-local-dev-secret-do-not-use-in-production';
-const token = jwt.sign({ sub: 'testuser' }, SECRET, { algorithm: 'HS256', expiresIn: '1h' });
+const token = jwt.sign(
+  { sub: 'testuser', channels: { subscribe: ['*'], publish: ['*'] } },
+  SECRET,
+  { algorithm: 'HS256', expiresIn: '1h' }
+);
 
 const orbit = new Orbit(`ws://localhost:8080/ws?token=${token}`);
 orbit.onConnected(() => {

--- a/tests/ws-pubsub.test.js
+++ b/tests/ws-pubsub.test.js
@@ -2,7 +2,11 @@ const WebSocket = require('ws');
 const jwt = require('jsonwebtoken');
 
 const SECRET = process.env.ORBIT_JWT_SECRET || 'orbit-local-dev-secret-do-not-use-in-production';
-const token = jwt.sign({ sub: 'testuser' }, SECRET, { algorithm: 'HS256', expiresIn: '1h' });
+const token = jwt.sign(
+  { sub: 'testuser', channels: { subscribe: ['*'], publish: ['*'] } },
+  SECRET,
+  { algorithm: 'HS256', expiresIn: '1h' }
+);
 
 const ws = new WebSocket(`ws://localhost:8080/ws?token=${token}`);
 


### PR DESCRIPTION
## Version
- [x] v0.1 — Trustworthy (security + survivability)
- [ ] v0.2 — Differentiated (presence primitives)
- [ ] v0.3 — Adoption (developer onboarding)
- [ ] v0.5 — Observable (durable messaging + observability)
- [ ] v1.0 — Platform (ecosystem + resilience)
- [ ] None / cross-cutting

## Summary
Implements channel-level ACLs via JWT `channels` claim. Deny by default — a token with no `channels` claim cannot subscribe or publish to any channel. Supports wildcard patterns (`room-*`, `*`).

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other (describe):

## Changes
<!-- List the key changes made -->
- Added `ChannelPermissions` type to `internal/auth/auth.go` — parsed from JWT `channels` claim at connect time
- `Authenticate()` now returns `(userID, *ChannelPermissions, error)` — permissions stored on `ws.Client`
- `CanSubscribe` / `CanPublish` are now pure functions in the `auth` package — zero per-message Redis/map lookups
- Wildcard matching: `room-*` matches `room-anything`, `*` allows all channels
- Publish denial now sends `{"type":"error"}` frame to client (was silently dropped)
- `DefaultRouter` no longer holds an `Authenticator` reference — ACL check is stateless
- Integration tests updated to include `channels: { subscribe: ["*"], publish: ["*"] }` claim

## Testing
<!-- How did you test this? -->
- [x] Ran `go vet ./...`
- [x] Ran integration tests (`node tests/ws-pubsub.test.js`, `node tests/sdk-presence.test.js`)
- [x] Manually tested against a running server
- [ ] Added new tests (if applicable)

## Related Issues
Closes #6

## Notes for reviewer
`*` in channels is intentional for trusted internal/dev tokens. End-user tokens should always use scoped channel patterns. The security boundary is the JWT secret — a client cannot forge a `*` claim without it.
