### PR TITLE
Graceful shutdown with in-flight message draining

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,7 +346,7 @@ Orbit's thesis: **self-hosted realtime infrastructure with strong presence primi
 - [x] Implement `CanSubscribe` / `CanPublish` channel-level ACLs
 - [x] Fix JS SDK `unsubscribe()` to send an unsubscribe frame to the server
 - [x] Connection rate limiting and per-user connection caps
-- [ ] Graceful shutdown with in-flight message draining
+- [x] Graceful shutdown with in-flight message draining
 - [ ] Slow consumer detection — per-connection outbound buffer limits and drop policy
 
 ### v0.2 — Presence Engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - ✅ Fix JS SDK `unsubscribe()` — now sends unsubscribe frame to server when last handler is removed
 - ✅ Fix `/api/presence` — all responses now return `Content-Type: application/json` (error paths were returning `text/plain`)
 - ✅ Connection rate limiting and per-user connection caps — token bucket per-IP limiter (`ORBIT_RATE_LIMIT_CONNS_PER_SEC`, default 10), per-user connection cap (`ORBIT_MAX_CONNS_PER_USER`, default 10), trusted proxy support; set either to `0` to disable
-- Graceful shutdown with in-flight message draining
+- ✅ Graceful shutdown — SIGTERM/SIGINT drains fanout workers, sends WebSocket close frames to all clients, stops HTTP listener; `ORBIT_SHUTDOWN_TIMEOUT` (default `10s`)
 - Slow consumer detection — per-connection outbound buffer limits and drop policy
 
 ### v0.2 — Presence Engine (planned)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Each Orbit node holds a single multiplexed Redis PubSub connection. Messages are
 | `ORBIT_RATE_LIMIT_CONNS_PER_SEC` | `10` | Max new WebSocket connections per second per IP. Set to `0` to disable (e.g. for load testing). |
 | `ORBIT_MAX_CONNS_PER_USER` | `10` | Max simultaneous WebSocket connections per userID. Set to `0` to disable. |
 | `ORBIT_TRUSTED_PROXY` | `false` | Set to `true` to trust `X-Forwarded-For` / `X-Real-IP` for IP rate limiting (use only behind a trusted reverse proxy) |
+| `ORBIT_SHUTDOWN_TIMEOUT` | `10s` | Maximum time to drain in-flight messages and close connections on SIGTERM/SIGINT (e.g. `30s`, `1m`) |
 
 ---
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/coder/websocket"
@@ -67,6 +71,10 @@ func main() {
 	trustedProxy := os.Getenv("ORBIT_TRUSTED_PROXY") == "true"
 	ipLimiter := ratelimit.NewIPRateLimiter(rateLimitConns, trustedProxy)
 
+	// Shutdown config
+	shutdownTimeout := envDuration("ORBIT_SHUTDOWN_TIMEOUT", 10*time.Second)
+	var shuttingDown atomic.Bool
+
 	// 2. Initialize Core Services
 	authenticator := auth.NewJWTAuthenticator(jwtSecret)
 	tracker := presence.NewTracker(redisClient, 45*time.Second) // 45s TTL
@@ -80,6 +88,12 @@ func main() {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		// Reject new connections during graceful shutdown.
+		if shuttingDown.Load() {
+			http.Error(w, "server shutting down", http.StatusServiceUnavailable)
+			return
+		}
+
 		// 1. Per-IP rate limit
 		if !ipLimiter.Allow(r) {
 			http.Error(w, "too many requests", http.StatusTooManyRequests)
@@ -147,15 +161,46 @@ func main() {
 	// Optionally map sdk files for dev usage
 	mux.Handle("/", http.FileServer(http.Dir("./sdk/js")))
 
-	log.Printf("Orbit core starting on :%s", port)
 	srv := &http.Server{
 		Addr:    ":" + port,
 		Handler: mux,
 	}
 
-	if err := srv.ListenAndServe(); err != nil {
-		log.Fatalf("Server failed: %v", err)
+	log.Printf("Orbit core starting on :%s", port)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server failed: %v", err)
+		}
+	}()
+
+	// Block until SIGTERM or SIGINT.
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGTERM, syscall.SIGINT)
+	<-quit
+
+	log.Println("Shutdown signal received, draining...")
+	shuttingDown.Store(true)
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer shutdownCancel()
+
+	// 1. Drain fanout worker queues so in-flight messages are delivered.
+	log.Println("Draining fanout workers...")
+	if err := pubsubEngine.Drain(shutdownCtx); err != nil {
+		log.Printf("Fanout drain deadline exceeded: %v", err)
 	}
+
+	// 2. Send close frames to all connected WebSocket clients and wait for them to finish.
+	log.Println("Closing WebSocket connections...")
+	gateway.Shutdown(shutdownCtx)
+
+	// 3. Stop accepting new HTTP requests.
+	log.Println("Stopping HTTP server...")
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("HTTP server shutdown error: %v", err)
+	}
+
+	log.Println("Orbit shut down cleanly.")
 }
 
 // envInt reads an integer from an environment variable, returning defaultVal if unset or invalid.
@@ -164,6 +209,17 @@ func envInt(key string, defaultVal int) int {
 	if v := os.Getenv(key); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 			return n
+		}
+	}
+	return defaultVal
+}
+
+// envDuration reads a time.Duration from an environment variable (e.g. "15s", "1m").
+// Returns defaultVal if unset or unparseable.
+func envDuration(key string, defaultVal time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
 		}
 	}
 	return defaultVal

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -10,5 +10,7 @@ type Engine interface {
 	Publish(ctx context.Context, channel string, payload []byte) error
 	Subscribe(ctx context.Context, channel string, handler MessageHandler) error
 	Unsubscribe(ctx context.Context, channel string) error
+	// Drain waits for all in-flight fanout jobs to be processed, or until ctx is cancelled.
+	Drain(ctx context.Context) error
 	Close() error
 }

--- a/internal/pubsub/redis.go
+++ b/internal/pubsub/redis.go
@@ -31,6 +31,8 @@ type RedisEngine struct {
 	workers    []chan dispatchJob
 	numWorkers int
 
+	wg         sync.WaitGroup // tracks in-flight fanout jobs
+
 	ctx        context.Context
 	cancelFunc context.CancelFunc
 }
@@ -174,16 +176,18 @@ func (r *RedisEngine) runDispatcher() {
 		backoff = 100 * time.Millisecond
 
 		job := dispatchJob{channel: msg.Channel, payload: []byte(msg.Payload)}
-		
+
 		h := fnv.New32a()
 		h.Write([]byte(job.channel))
 		idx := h.Sum32() % uint32(r.numWorkers)
 
-		// Push to worker queue with active backpressure detection
+		// Track the job before enqueuing; Done() is called by the worker (or here on drop).
+		r.wg.Add(1)
 		select {
 		case r.workers[idx] <- job:
 			// Job scheduled successfully
 		default:
+			r.wg.Done()
 			metrics.DroppedMessagesTotal.Inc()
 			// Sample 1% of drops to avoid flooding standard output I/O
 			if rand.Float32() < 0.01 {
@@ -228,6 +232,22 @@ func (r *RedisEngine) runWorker(ctx context.Context, ch chan dispatchJob) {
 				handler(job.channel, job.payload)
 				metrics.FanoutLatency.Observe(time.Since(start).Seconds())
 			}
+			r.wg.Done()
 		}
+	}
+}
+
+// Drain waits for all in-flight fanout worker jobs to complete, or until ctx is cancelled.
+func (r *RedisEngine) Drain(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }

--- a/internal/ws/gateway.go
+++ b/internal/ws/gateway.go
@@ -1,8 +1,10 @@
 package ws
 
 import (
+	"context"
 	"sync"
 
+	"github.com/coder/websocket"
 	"github.com/orbit/orbit/internal/metrics"
 )
 
@@ -15,6 +17,10 @@ type Gateway struct {
 
 	maxConnsPerUser int
 	userConns       map[string]int // userID -> active connection count
+
+	wg   sync.WaitGroup // tracks registered connections; Done on Unregister
+	done chan struct{}   // closed by Shutdown to stop Run()
+	once sync.Once      // ensures done is closed exactly once
 }
 
 func NewGateway(maxConnsPerUser int) *Gateway {
@@ -24,12 +30,16 @@ func NewGateway(maxConnsPerUser int) *Gateway {
 		Clients:         make(map[*Client]bool),
 		maxConnsPerUser: maxConnsPerUser,
 		userConns:       make(map[string]int),
+		done:            make(chan struct{}),
 	}
 }
 
-// ConnCount returns the current number of open connections for a userID.
-// Returns (count, overLimit) — overLimit is true if adding one more would exceed the cap.
+// AllowConnection returns true if the given userID may open another connection.
+// A maxConnsPerUser of 0 means no cap (unlimited).
 func (g *Gateway) AllowConnection(userID string) bool {
+	if g.maxConnsPerUser == 0 {
+		return true
+	}
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 	return g.userConns[userID] < g.maxConnsPerUser
@@ -38,10 +48,13 @@ func (g *Gateway) AllowConnection(userID string) bool {
 func (g *Gateway) Run() {
 	for {
 		select {
+		case <-g.done:
+			return
 		case client := <-g.Register:
 			g.mu.Lock()
 			g.Clients[client] = true
 			g.userConns[client.UserID]++
+			g.wg.Add(1)
 			metrics.ActiveConnections.Inc()
 			g.mu.Unlock()
 
@@ -57,10 +70,43 @@ func (g *Gateway) Run() {
 				if g.userConns[client.UserID] == 0 {
 					delete(g.userConns, client.UserID)
 				}
+				g.wg.Done()
 			}
 			g.mu.Unlock()
 		}
 	}
+}
+
+// Shutdown sends a clean WebSocket close frame to every connected client, waits for
+// all connections to finish (or ctx to expire), then stops the Run() loop.
+func (g *Gateway) Shutdown(ctx context.Context) {
+	// Snapshot connected clients under read lock.
+	g.mu.RLock()
+	clients := make([]*Client, 0, len(g.Clients))
+	for c := range g.Clients {
+		clients = append(clients, c)
+	}
+	g.mu.RUnlock()
+
+	// Send GoingAway close frame to each client.
+	// This causes each ReadPump to receive an error and send to Unregister.
+	for _, c := range clients {
+		c.Conn.Close(websocket.StatusGoingAway, "server shutting down")
+	}
+
+	// Wait for all Unregister events to be processed by Run() (wg.Done per client).
+	waitDone := make(chan struct{})
+	go func() {
+		g.wg.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+	case <-ctx.Done():
+	}
+
+	// Stop the Run() loop.
+	g.once.Do(func() { close(g.done) })
 }
 
 func (g *Gateway) BroadcastLocal(channel string, env interface{}) {


### PR DESCRIPTION
Shutdown sequence on SIGTERM/SIGINT:
1. Set shuttingDown flag → /ws handler returns 503 for new connections
2. pubsubEngine.Drain(ctx) — wait for fanout worker queues to empty
3. gateway.Shutdown(ctx) — send GoingAway close frames to all WS clients, wait for all ReadPumps to exit via WaitGroup
4. http.Server.Shutdown(ctx) — stop HTTP listener cleanly

Changes:
- internal/pubsub/pubsub.go: add Drain(ctx) to Engine interface
- internal/pubsub/redis.go: track in-flight jobs with sync.WaitGroup; implement Drain() waiting on wg.Wait() with context deadline
- internal/ws/gateway.go: add wg (Register increments, Unregister decrements), done channel + once for Run() lifecycle; add Shutdown(ctx); fix AllowConnection to treat maxConnsPerUser=0 as unlimited
- cmd/server/main.go: signal.Notify(SIGTERM/SIGINT), atomic.Bool shuttingDown, ORBIT_SHUTDOWN_TIMEOUT env var (default 10s), envDuration helper, server started in goroutine, shutdown sequence in main goroutine
- README.md: document ORBIT_SHUTDOWN_TIMEOUT

## Version
<!-- Which roadmap version does this PR belong to? -->
- [x] v0.1 — Trustworthy (security + survivability)
- [ ] v0.2 — Differentiated (presence primitives)
- [ ] v0.3 — Adoption (developer onboarding)
- [ ] v0.5 — Observable (durable messaging + observability)
- [ ] v1.0 — Platform (ecosystem + resilience)
- [ ] None / cross-cutting

## Summary
<!-- What does this PR do? One or two sentences. -->
Graceful shutdown with in-flight message draining

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other (describe):

## Changes
<!-- List the key changes made -->
- internal/pubsub/pubsub.go: add Drain(ctx) to Engine interface
- internal/pubsub/redis.go: track in-flight jobs with sync.WaitGroup; implement Drain() waiting on wg.Wait() with context deadline
- internal/ws/gateway.go: add wg (Register increments, Unregister decrements), done channel + once for Run() lifecycle; add Shutdown(ctx); fix AllowConnection to treat maxConnsPerUser=0 as unlimited
- cmd/server/main.go: signal.Notify(SIGTERM/SIGINT), atomic.Bool shuttingDown, ORBIT_SHUTDOWN_TIMEOUT env var (default 10s), envDuration helper, server started in goroutine, shutdown sequence in main goroutine
- README.md: document ORBIT_SHUTDOWN_TIMEOUT
## Testing
<!-- How did you test this? -->
- [ ] Ran `go vet ./...`
- [ ] Ran integration tests (`node tests/ws-pubsub.test.js`, `node tests/sdk-presence.test.mjs`)
- [ ] Manually tested against a running server
- [ ] Added new tests (if applicable)

## Related Issues
Closes #10 

## Notes for reviewer
<!-- Anything the reviewer should pay special attention to? -->
