### PR TITLE
feat(#11): slow consumer detection — per-connection outbound buffer imits and drop policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,7 +347,7 @@ Orbit's thesis: **self-hosted realtime infrastructure with strong presence primi
 - [x] Fix JS SDK `unsubscribe()` to send an unsubscribe frame to the server
 - [x] Connection rate limiting and per-user connection caps
 - [x] Graceful shutdown with in-flight message draining
-- [ ] Slow consumer detection — per-connection outbound buffer limits and drop policy
+- [x] Slow consumer detection — per-connection outbound buffer limits and drop policy
 
 ### v0.2 — Presence Engine
 > Focus Orbit on the presence and multiplayer primitive space.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - ✅ Fix `/api/presence` — all responses now return `Content-Type: application/json` (error paths were returning `text/plain`)
 - ✅ Connection rate limiting and per-user connection caps — token bucket per-IP limiter (`ORBIT_RATE_LIMIT_CONNS_PER_SEC`, default 10), per-user connection cap (`ORBIT_MAX_CONNS_PER_USER`, default 10), trusted proxy support; set either to `0` to disable
 - ✅ Graceful shutdown — SIGTERM/SIGINT drains fanout workers, sends WebSocket close frames to all clients, stops HTTP listener; `ORBIT_SHUTDOWN_TIMEOUT` (default `10s`)
-- Slow consumer detection — per-connection outbound buffer limits and drop policy
+- ✅ Slow consumer detection — per-connection outbound buffer (`ORBIT_CLIENT_BUFFER_SIZE`, default 256); consecutive-drop counter disconnects slow clients with 1008 Policy Violation after `ORBIT_SLOW_CLIENT_THRESHOLD` drops (default 50); `orbit_dropped_messages_total` incremented per drop
 
 ### v0.2 — Presence Engine (planned)
 - Occupancy counts per channel (live member count API)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Each Orbit node holds a single multiplexed Redis PubSub connection. Messages are
 | `ORBIT_MAX_CONNS_PER_USER` | `10` | Max simultaneous WebSocket connections per userID. Set to `0` to disable. |
 | `ORBIT_TRUSTED_PROXY` | `false` | Set to `true` to trust `X-Forwarded-For` / `X-Real-IP` for IP rate limiting (use only behind a trusted reverse proxy) |
 | `ORBIT_SHUTDOWN_TIMEOUT` | `10s` | Maximum time to drain in-flight messages and close connections on SIGTERM/SIGINT (e.g. `30s`, `1m`) |
+| `ORBIT_CLIENT_BUFFER_SIZE` | `256` | Per-connection outbound message buffer size. Increase for bursty workloads; messages beyond the buffer are dropped. |
+| `ORBIT_SLOW_CLIENT_THRESHOLD` | `50` | Consecutive drops before a slow client is disconnected with close code 1008. Set to `0` to disable forced disconnect (drops only). |
 
 ---
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -71,6 +71,10 @@ func main() {
 	trustedProxy := os.Getenv("ORBIT_TRUSTED_PROXY") == "true"
 	ipLimiter := ratelimit.NewIPRateLimiter(rateLimitConns, trustedProxy)
 
+	// Slow consumer config
+	clientBufSize := envInt("ORBIT_CLIENT_BUFFER_SIZE", 256)
+	slowClientThreshold := envInt("ORBIT_SLOW_CLIENT_THRESHOLD", 50)
+
 	// Shutdown config
 	shutdownTimeout := envDuration("ORBIT_SHUTDOWN_TIMEOUT", 10*time.Second)
 	var shuttingDown atomic.Bool
@@ -122,7 +126,7 @@ func main() {
 		}
 
 		id := uuid.New().String()
-		client := ws.NewClient(id, userID, perms, conn, gateway, msgRouter)
+		client := ws.NewClient(id, userID, perms, conn, gateway, msgRouter, clientBufSize, slowClientThreshold)
 		
 		gateway.Register <- client
 

--- a/internal/ws/client.go
+++ b/internal/ws/client.go
@@ -3,12 +3,14 @@ package ws
 import (
 	"context"
 	"log"
+	"sync/atomic"
 	"time"
 
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
 	"github.com/orbit/orbit/internal/auth"
 	"github.com/orbit/orbit/internal/core"
+	"github.com/orbit/orbit/internal/metrics"
 )
 
 const (
@@ -32,22 +34,29 @@ type Client struct {
 	Gateway *Gateway
 	Router  Router
 
+	// Slow-consumer detection: counts consecutive dropped messages.
+	// Reset to 0 on any successful queue. When it reaches slowThreshold the
+	// client is disconnected with 1008 Policy Violation.
+	slowThreshold int
+	dropCount     atomic.Int32
+
 	ctx        context.Context
 	cancelFunc context.CancelFunc
 }
 
-func NewClient(id, userID string, perms *auth.ChannelPermissions, conn *websocket.Conn, gateway *Gateway, router Router) *Client {
+func NewClient(id, userID string, perms *auth.ChannelPermissions, conn *websocket.Conn, gateway *Gateway, router Router, bufSize, slowThreshold int) *Client {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Client{
-		ID:          id,
-		UserID:      userID,
-		Permissions: perms,
-		Conn:        conn,
-		Send:        make(chan core.Envelope, 256),
-		Gateway:     gateway,
-		Router:      router,
-		ctx:         ctx,
-		cancelFunc:  cancel,
+		ID:            id,
+		UserID:        userID,
+		Permissions:   perms,
+		Conn:          conn,
+		Send:          make(chan core.Envelope, bufSize),
+		Gateway:       gateway,
+		Router:        router,
+		slowThreshold: slowThreshold,
+		ctx:           ctx,
+		cancelFunc:    cancel,
 	}
 }
 
@@ -124,10 +133,18 @@ func (c *Client) WritePump() {
 func (c *Client) SendJSON(env core.Envelope) {
 	select {
 	case c.Send <- env:
+		// Successful queue — reset the consecutive drop counter.
+		c.dropCount.Store(0)
 	case <-c.ctx.Done():
 		return
-	default: // Channel full, indicating slow client
-		log.Printf("WARN: Slow client %s backpressure limit reached. Disconnecting user aggressively.", c.UserID)
-		c.cancelFunc()
+	default:
+		// Buffer full: client is reading too slowly.
+		metrics.DroppedMessagesTotal.Inc()
+		drops := c.dropCount.Add(1)
+		if c.slowThreshold > 0 && int(drops) >= c.slowThreshold {
+			log.Printf("Slow consumer: disconnecting client %s (%d consecutive drops)", c.UserID, drops)
+			c.Conn.Close(websocket.StatusPolicyViolation, "slow consumer")
+			c.cancelFunc()
+		}
 	}
 }


### PR DESCRIPTION
## Version
- [x] v0.1 — Trustworthy (security + survivability)
- [ ] v0.2 — Differentiated (presence primitives)
- [ ] v0.3 — Adoption (developer onboarding)
- [ ] v0.5 — Observable (durable messaging + observability)
- [ ] v1.0 — Platform (ecosystem + resilience)
- [ ] None / cross-cutting

## Summary
- Add dropCount atomic.Int32 and slowThreshold int to Client
- NewClient now takes bufSize and slowThreshold params (read from env in main.go)
- SendJSON: on buffer full → increment orbit_dropped_messages_total, increment consecutive drop counter; after slowThreshold consecutive drops → disconnect with websocket.StatusPolicyViolation (1008) and log userID + drop count
- On successful queue → reset drop counter to 0 (consecutive, not cumulative)
- Fixed existing bug: previous SendJSON disconnected on first drop with no metric
- ORBIT_CLIENT_BUFFER_SIZE (default 256): per-connection Send channel capacity
- ORBIT_SLOW_CLIENT_THRESHOLD (default 50): consecutive drops before disconnect; set to 0 to disable forced disconnect (drops only)
- README: document two new env vars

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other (describe):

## Changes
- Add dropCount atomic.Int32 and slowThreshold int to Client
- NewClient now takes bufSize and slowThreshold params (read from env in main.go)
- SendJSON: on buffer full → increment orbit_dropped_messages_total, increment consecutive drop counter; after slowThreshold consecutive drops → disconnect with websocket.StatusPolicyViolation (1008) and log userID + drop count
- On successful queue → reset drop counter to 0 (consecutive, not cumulative)
- Fixed existing bug: previous SendJSON disconnected on first drop with no metric
- ORBIT_CLIENT_BUFFER_SIZE (default 256): per-connection Send channel capacity
- ORBIT_SLOW_CLIENT_THRESHOLD (default 50): consecutive drops before disconnect; set to 0 to disable forced disconnect (drops only)
- README: document two new env vars

## Testing
<!-- How did you test this? -->
- [ ] Ran `go vet ./...`
- [ ] Ran integration tests (`node tests/ws-pubsub.test.js`, `node tests/sdk-presence.test.mjs`)
- [ ] Manually tested against a running server
- [ ] Added new tests (if applicable)

## Related Issues
<!-- Closes #123 -->

## Notes for reviewer
<!-- Anything the reviewer should pay special attention to? -->
