### PR TITLE
feat: add GET /api/presence/count endpoint (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Each Orbit node holds a single multiplexed Redis PubSub connection. Messages are
 |---|---|---|
 | `GET` | `/ws?token=<token>` | WebSocket upgrade endpoint |
 | `GET` | `/api/presence?channel=<channel>` | Returns JSON array of active user IDs in a channel |
+| `GET` | `/api/presence/count?channel=<channel>` | Returns the current occupancy count for a channel |
 | `GET` | `/metrics` | Prometheus metrics scrape endpoint |
 
 ---

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -162,6 +162,31 @@ func main() {
 		})
 	})
 
+	// Occupancy count endpoint
+	mux.HandleFunc("/api/presence/count", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Content-Type", "application/json")
+
+		channel := r.URL.Query().Get("channel")
+		if channel == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"missing channel parameter"}`))
+			return
+		}
+
+		count, err := tracker.Count(r.Context(), channel)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"internal server error"}`))
+			return
+		}
+
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"channel": channel,
+			"count":   count,
+		})
+	})
+
 	// Optionally map sdk files for dev usage
 	mux.Handle("/", http.FileServer(http.Dir("./sdk/js")))
 


### PR DESCRIPTION
## Summary

Exposes the existing `tracker.Count()` method as a lightweight HTTP endpoint so callers can get channel occupancy without fetching the full user list.

## Changes

- `cmd/server/main.go`: new `GET /api/presence/count?channel=<channel>` handler
- `README.md`: document the new endpoint in the HTTP endpoints table

## Endpoint

```
GET /api/presence/count?channel=live-canvas
```
```json
{ "channel": "live-canvas", "count": 42 }
```

- Missing `channel` → `400 Bad Request`
- TTL-expired members are excluded (handled inside `Count()` via `Clean()`)

Closes #23