### PR TITLE
feat: REST publish API — POST /api/publish endpoint (#27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
           PORT: 8080
           REDIS_URL: redis://localhost:6379
           ORBIT_JWT_SECRET: orbit-ci-test-secret-do-not-use-in-production
+          ORBIT_SERVER_SECRET: orbit-ci-server-secret-do-not-use-in-production
 
       - name: Run integration test (raw WebSocket)
         run: node tests/ws-pubsub.test.js
@@ -99,3 +100,9 @@ jobs:
         run: node tests/sdk-presence.test.mjs
         env:
           ORBIT_JWT_SECRET: orbit-ci-test-secret-do-not-use-in-production
+
+      - name: Run integration test (REST publish API)
+        run: node tests/rest-publish.test.mjs
+        env:
+          ORBIT_JWT_SECRET: orbit-ci-test-secret-do-not-use-in-production
+          ORBIT_SERVER_SECRET: orbit-ci-server-secret-do-not-use-in-production

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,8 @@ orbit/
 │       └── components/Cursor.jsx  # Animated LERP cursor component
 ├── tests/
 │   ├── ws-pubsub.test.js       # Node.js raw WebSocket integration test
-│   └── sdk-presence.test.mjs   # Node.js Orbit SDK integration test
+│   ├── sdk-presence.test.mjs   # Node.js Orbit SDK integration test
+│   └── rest-publish.test.mjs   # REST publish API integration test
 ├── Dockerfile                  # Multi-stage Go build → alpine runtime
 ├── docker-compose.yml          # Redis + Orbit service definitions
 └── go.mod                      # Go module: github.com/orbit/orbit
@@ -296,11 +297,13 @@ npm run dev
 |---|---|
 | `tests/ws-pubsub.test.js` | Raw `ws` WebSocket: subscribe to `room-1`, publish, verify message received back |
 | `tests/sdk-presence.test.mjs` | Orbit SDK: connect, subscribe to `global-hub`, verify `presence.joined` fires |
+| `tests/rest-publish.test.mjs` | REST publish API: POST to `/api/publish`, verify WS subscriber receives message; 400/401/405 error cases |
 
 Run with Node.js after starting the server:
 ```bash
 node tests/ws-pubsub.test.js
 node tests/sdk-presence.test.mjs
+node tests/rest-publish.test.mjs
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Each Orbit node holds a single multiplexed Redis PubSub connection. Messages are
 | `ORBIT_CLIENT_BUFFER_SIZE` | `256` | Per-connection outbound message buffer size. Increase for bursty workloads; messages beyond the buffer are dropped. |
 | `ORBIT_SLOW_CLIENT_THRESHOLD` | `50` | Consecutive drops before a slow client is disconnected with close code 1008. Set to `0` to disable forced disconnect (drops only). |
 | `ORBIT_PRESENCE_TTL_SECONDS` | `45` | How long (in seconds) a user is considered online after their last activity. Accepted range: 5–3600. Per-channel overrides can be set via the `ttl` field in a `subscribe` frame. |
+| `ORBIT_SERVER_SECRET` | _(required)_ | Shared secret protecting the `POST /api/publish` endpoint. Server refuses to start if unset. Must never be exposed to WebSocket clients. |
 
 ---
 
@@ -125,6 +126,7 @@ Each Orbit node holds a single multiplexed Redis PubSub connection. Messages are
 | `GET` | `/ws?token=<token>` | WebSocket upgrade endpoint |
 | `GET` | `/api/presence?channel=<channel>` | Returns JSON array of active user IDs in a channel |
 | `GET` | `/api/presence/count?channel=<channel>` | Returns the current occupancy count for a channel |
+| `POST` | `/api/publish` | Publish a message to a channel from a backend service. Requires `Authorization: Bearer <ORBIT_SERVER_SECRET>`. |
 | `GET` | `/metrics` | Prometheus metrics scrape endpoint |
 
 ---

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -41,6 +41,11 @@ func main() {
 		log.Fatal("ORBIT_JWT_SECRET must be set and at least 32 characters long")
 	}
 
+	serverSecret := os.Getenv("ORBIT_SERVER_SECRET")
+	if serverSecret == "" {
+		log.Fatal("ORBIT_SERVER_SECRET must be set — it protects the REST publish endpoint")
+	}
+
 	// 1. Initialize Redis Engine
 	pubsubEngine, err := pubsub.NewRedisEngine(redisURL)
 	if err != nil {
@@ -161,6 +166,54 @@ func main() {
 			"channel": channel,
 			"users":   users,
 		})
+	})
+
+	// REST publish endpoint — allows backend services to publish to a channel over HTTP.
+	mux.HandleFunc("/api/publish", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			w.Write([]byte(`{"ok":false,"error":"method not allowed"}`))
+			return
+		}
+
+		// Bearer token auth against ORBIT_SERVER_SECRET.
+		authhdr := r.Header.Get("Authorization")
+		if len(authhdr) < 8 || authhdr[:7] != "Bearer " || authhdr[7:] != serverSecret {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"ok":false,"error":"unauthorized"}`))
+			return
+		}
+
+		var body struct {
+			Channel string          `json:"channel"`
+			Event   string          `json:"event"`
+			Payload json.RawMessage `json:"payload"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"ok":false,"error":"invalid JSON body"}`))
+			return
+		}
+		if body.Channel == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"ok":false,"error":"channel is required"}`))
+			return
+		}
+
+		envelope, _ := json.Marshal(map[string]interface{}{
+			"type":    "publish",
+			"channel": body.Channel,
+			"event":   body.Event,
+			"payload": body.Payload,
+		})
+		if err := pubsubEngine.Publish(r.Context(), body.Channel, envelope); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"ok":false,"error":"internal server error"}`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true}`))
 	})
 
 	// Occupancy count endpoint

--- a/tests/rest-publish.test.mjs
+++ b/tests/rest-publish.test.mjs
@@ -1,0 +1,154 @@
+/**
+ * Integration test: REST publish API
+ *
+ * Verifies that POSTing to /api/publish delivers a message to a connected
+ * WebSocket subscriber on the same channel.
+ *
+ * Prerequisites:
+ *   - Orbit server running on localhost:8080
+ *   - ORBIT_JWT_SECRET and ORBIT_SERVER_SECRET set (or use defaults below)
+ *
+ * Run:
+ *   node tests/rest-publish.test.mjs
+ */
+
+import WebSocket from 'ws';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = process.env.ORBIT_JWT_SECRET || 'orbit-local-dev-secret-do-not-use-in-production';
+const SERVER_SECRET = process.env.ORBIT_SERVER_SECRET || 'orbit-server-secret-do-not-use-in-production';
+const BASE_URL = process.env.ORBIT_URL || 'http://localhost:8080';
+const WS_URL = BASE_URL.replace(/^http/, 'ws');
+
+const CHANNEL = `rest-publish-test-${Date.now()}`;
+
+const token = jwt.sign(
+  { sub: 'resttest', channels: { subscribe: ['*'], publish: ['*'] } },
+  JWT_SECRET,
+  { algorithm: 'HS256', expiresIn: '1h' }
+);
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) {
+    console.log(`  ✓ ${label}`);
+    passed++;
+  } else {
+    console.error(`  ✗ ${label}`);
+    failed++;
+  }
+}
+
+async function run() {
+  console.log('REST publish API integration test\n');
+
+  // --- Test 1: message delivered to WS subscriber ---
+  console.log('1. POST /api/publish delivers message to WebSocket subscriber');
+  await new Promise((resolve) => {
+    const ws = new WebSocket(`${WS_URL}/ws?token=${token}`);
+
+    ws.once('open', () => {
+      ws.send(JSON.stringify({ type: 'subscribe', channel: CHANNEL }));
+
+      // Give the subscription a moment to register, then publish via HTTP.
+      setTimeout(async () => {
+        const res = await fetch(`${BASE_URL}/api/publish`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${SERVER_SECRET}`,
+          },
+          body: JSON.stringify({
+            channel: CHANNEL,
+            event: 'payment.completed',
+            payload: { amount: 99.00, currency: 'USD' },
+          }),
+        });
+
+        const body = await res.json();
+        assert(res.status === 200, `POST /api/publish returns 200`);
+        assert(body.ok === true, `response body is { ok: true }`);
+      }, 150);
+    });
+
+    ws.on('message', (raw) => {
+      const msg = JSON.parse(raw.toString());
+      if (msg.event === 'payment.completed') {
+        assert(msg.type === 'message', `received type is "message"`);
+        assert(msg.channel === CHANNEL, `received channel matches`);
+        assert(msg.payload?.currency === 'USD', `payload forwarded correctly`);
+        ws.close();
+        resolve();
+      }
+    });
+
+    setTimeout(() => {
+      console.error('  ✗ timed out waiting for message');
+      failed++;
+      ws.close();
+      resolve();
+    }, 3000);
+  });
+
+  // --- Test 2: missing channel returns 400 ---
+  console.log('\n2. Missing channel field returns 400');
+  {
+    const res = await fetch(`${BASE_URL}/api/publish`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${SERVER_SECRET}`,
+      },
+      body: JSON.stringify({ event: 'test' }),
+    });
+    const body = await res.json();
+    assert(res.status === 400, `status is 400`);
+    assert(body.ok === false, `body.ok is false`);
+  }
+
+  // --- Test 3: wrong secret returns 401 ---
+  console.log('\n3. Wrong Authorization secret returns 401');
+  {
+    const res = await fetch(`${BASE_URL}/api/publish`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer wrong-secret',
+      },
+      body: JSON.stringify({ channel: CHANNEL, event: 'test' }),
+    });
+    const body = await res.json();
+    assert(res.status === 401, `status is 401`);
+    assert(body.ok === false, `body.ok is false`);
+  }
+
+  // --- Test 4: missing Authorization header returns 401 ---
+  console.log('\n4. Missing Authorization header returns 401');
+  {
+    const res = await fetch(`${BASE_URL}/api/publish`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ channel: CHANNEL, event: 'test' }),
+    });
+    const body = await res.json();
+    assert(res.status === 401, `status is 401`);
+    assert(body.ok === false, `body.ok is false`);
+  }
+
+  // --- Test 5: wrong HTTP method returns 405 ---
+  console.log('\n5. GET /api/publish returns 405');
+  {
+    const res = await fetch(`${BASE_URL}/api/publish`, { method: 'GET' });
+    assert(res.status === 405, `status is 405`);
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch((err) => {
+  console.error('Unexpected error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Lets backend services (cron jobs, webhooks, workers) publish to any Orbit channel over plain HTTP — no WebSocket connection needed.

## Endpoint

```
POST /api/publish
Authorization: Bearer <ORBIT_SERVER_SECRET>
Content-Type: application/json

{
  "channel": "notifications",
  "event":   "payment.completed",
  "payload": { "amount": 99.00, "currency": "USD" }
}
```

| Case | Status | Body |
|---|---|---|
| Success | 200 | `{ "ok": true }` |
| Missing/wrong secret | 401 | `{ "ok": false, "error": "unauthorized" }` |
| Missing channel | 400 | `{ "ok": false, "error": "channel is required" }` |
| Wrong HTTP method | 405 | `{ "ok": false, "error": "method not allowed" }` |

## Authentication

`ORBIT_SERVER_SECRET` env var — required at startup (server refuses to start if unset). Separate from `ORBIT_JWT_SECRET`; never exposed to WebSocket clients.

## Behaviour

Publishes a `TypePublish` envelope into Redis PubSub. The router's existing `handleRedisMessage` converts it to `TypeMessage` before delivering to all channel subscribers on all nodes.

## Files changed

- `cmd/server/main.go` — `ORBIT_SERVER_SECRET` startup check + `/api/publish` handler
- `tests/rest-publish.test.mjs` — integration test (5 test cases)
- `README.md` — new endpoint + env var rows
- `AGENTS.md` — integration tests table + file tree

Closes #27