### PR TITLE
feat: room metadata — attach arbitrary state to a presence entry (#25)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -155,7 +155,7 @@ func main() {
 			return
 		}
 
-		users, err := tracker.GetUsers(r.Context(), channel)
+		entries, err := tracker.GetUsersWithMetadata(r.Context(), channel)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(`{"error":"internal server error"}`))
@@ -164,7 +164,7 @@ func main() {
 
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"channel": channel,
-			"users":   users,
+			"users":   entries,
 		})
 	})
 

--- a/internal/core/message.go
+++ b/internal/core/message.go
@@ -22,4 +22,8 @@ type Envelope struct {
 	// TTL is an optional presence TTL in seconds, valid only on subscribe frames.
 	// Accepted range: 5–3600. Falls back to the server default when zero or absent.
 	TTL int `json:"ttl,omitempty"`
+	// Metadata is an optional opaque JSON object, valid only on subscribe frames.
+	// Max 2 KB serialised. Stored alongside the presence entry and forwarded in
+	// presence.joined events.
+	Metadata json.RawMessage `json:"metadata,omitempty"`
 }

--- a/internal/presence/tracker.go
+++ b/internal/presence/tracker.go
@@ -2,6 +2,7 @@ package presence
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -48,7 +49,6 @@ func (t *Tracker) Clean(ctx context.Context, channel string) error {
 
 // Count returns the number of active users in the channel.
 func (t *Tracker) Count(ctx context.Context, channel string) (int64, error) {
-	// Clean first to get an accurate count
 	t.Clean(ctx, channel)
 	key := fmt.Sprintf("orbit:presence:%s", channel)
 	return t.client.ZCard(ctx, key).Result()
@@ -56,8 +56,56 @@ func (t *Tracker) Count(ctx context.Context, channel string) (int64, error) {
 
 // GetUsers returns the list of active user IDs in the channel.
 func (t *Tracker) GetUsers(ctx context.Context, channel string) ([]string, error) {
-	// Clean first to get an accurate list
 	t.Clean(ctx, channel)
 	key := fmt.Sprintf("orbit:presence:%s", channel)
 	return t.client.ZRange(ctx, key, 0, -1).Result()
+}
+
+// SetMetadata stores opaque JSON metadata for a user in a channel.
+// The metadata key uses a 2×TTL expiry, matching the sorted-set key.
+func (t *Tracker) SetMetadata(ctx context.Context, channel, userID string, ttl time.Duration, metadata json.RawMessage) error {
+	key := fmt.Sprintf("orbit:presence:meta:%s:%s", channel, userID)
+	return t.client.Set(ctx, key, []byte(metadata), ttl*2).Err()
+}
+
+// RefreshMetadata extends the expiry of a user's metadata key.
+func (t *Tracker) RefreshMetadata(ctx context.Context, channel, userID string, ttl time.Duration) {
+	key := fmt.Sprintf("orbit:presence:meta:%s:%s", channel, userID)
+	t.client.Expire(ctx, key, ttl*2)
+}
+
+// RemoveMetadata deletes a user's metadata key for a channel.
+func (t *Tracker) RemoveMetadata(ctx context.Context, channel, userID string) {
+	key := fmt.Sprintf("orbit:presence:meta:%s:%s", channel, userID)
+	t.client.Del(ctx, key)
+}
+
+// PresenceEntry holds a user ID and their optional metadata for API responses.
+type PresenceEntry struct {
+	User     string          `json:"user"`
+	Metadata json.RawMessage `json:"metadata"`
+}
+
+// GetUsersWithMetadata returns active users paired with their stored metadata.
+// Users without metadata get an empty object ({}).
+func (t *Tracker) GetUsersWithMetadata(ctx context.Context, channel string) ([]PresenceEntry, error) {
+	users, err := t.GetUsers(ctx, channel)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]PresenceEntry, 0, len(users))
+	for _, u := range users {
+		entries = append(entries, PresenceEntry{User: u, Metadata: t.getMetadata(ctx, channel, u)})
+	}
+	return entries, nil
+}
+
+// getMetadata retrieves stored metadata or returns an empty JSON object.
+func (t *Tracker) getMetadata(ctx context.Context, channel, userID string) json.RawMessage {
+	key := fmt.Sprintf("orbit:presence:meta:%s:%s", channel, userID)
+	val, err := t.client.Get(ctx, key).Bytes()
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return val
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -31,17 +31,20 @@ type DefaultRouter struct {
 	subscriptions map[string]map[*ws.Client]bool
 	// clientChannelTTLs stores per-client per-channel TTL overrides from subscribe frames.
 	clientChannelTTLs map[*ws.Client]map[string]time.Duration
+	// clientChannelMetadata stores per-client per-channel metadata from subscribe frames.
+	clientChannelMetadata map[*ws.Client]map[string]json.RawMessage
 }
 
 func NewDefaultRouter(p pubsub.Engine, pr *presence.Tracker, g *ws.Gateway, defaultTTL time.Duration) *DefaultRouter {
 	return &DefaultRouter{
-		pubsub:            p,
-		presence:          pr,
-		gateway:           g,
-		metrics:           &RouterMetrics{},
-		defaultTTL:        defaultTTL,
-		subscriptions:     make(map[string]map[*ws.Client]bool),
-		clientChannelTTLs: make(map[*ws.Client]map[string]time.Duration),
+		pubsub:                p,
+		presence:              pr,
+		gateway:               g,
+		metrics:               &RouterMetrics{},
+		defaultTTL:            defaultTTL,
+		subscriptions:         make(map[string]map[*ws.Client]bool),
+		clientChannelTTLs:     make(map[*ws.Client]map[string]time.Duration),
+		clientChannelMetadata: make(map[*ws.Client]map[string]json.RawMessage),
 	}
 }
 
@@ -55,11 +58,13 @@ func (r *DefaultRouter) HandleDisconnect(ctx context.Context, client *ws.Client)
 	defer r.mu.Unlock()
 
 	delete(r.clientChannelTTLs, client)
+	delete(r.clientChannelMetadata, client)
 
 	for channel, clients := range r.subscriptions {
 		if _, ok := clients[client]; ok {
 			delete(clients, client)
 			r.presence.Remove(context.Background(), channel, client.UserID)
+			r.presence.RemoveMetadata(context.Background(), channel, client.UserID)
 			
 			// Broadcast presence.left
 			b, _ := json.Marshal(core.Envelope{
@@ -135,14 +140,35 @@ func (r *DefaultRouter) handleSubscribe(ctx context.Context, client *ws.Client, 
 	}
 	r.clientChannelTTLs[client][channel] = ttl
 
+	// Validate and store metadata if provided (max 2 KB).
+	const maxMetadataBytes = 2048
+	var metadata json.RawMessage
+	if len(msg.Metadata) > 0 {
+		if len(msg.Metadata) > maxMetadataBytes {
+			client.SendJSON(core.Envelope{Type: "error", Payload: json.RawMessage(`{"error":"metadata exceeds 2 KB limit"}`)}) 
+			// Proceed with subscription but without metadata.
+		} else {
+			metadata = msg.Metadata
+			r.presence.SetMetadata(ctx, channel, client.UserID, ttl, metadata)
+			if _, ok := r.clientChannelMetadata[client]; !ok {
+				r.clientChannelMetadata[client] = make(map[string]json.RawMessage)
+			}
+			r.clientChannelMetadata[client][channel] = metadata
+		}
+	}
+
 	r.presence.Heartbeat(ctx, channel, client.UserID, ttl)
 
-	// Broadcast presence.joined
+	// Broadcast presence.joined, including any metadata.
+	joinedPayload, _ := json.Marshal(map[string]interface{}{
+		"user":     client.UserID,
+		"metadata": metadataOrEmpty(metadata),
+	})
 	b, _ := json.Marshal(core.Envelope{
 		Type:    core.TypeMessage,
 		Channel: channel,
 		Event:   "presence.joined",
-		Payload: json.RawMessage(`{"user":"` + client.UserID + `"}`),
+		Payload: joinedPayload,
 	})
 	r.pubsub.Publish(ctx, channel, b)
 }
@@ -163,7 +189,11 @@ func (r *DefaultRouter) handlePublish(ctx context.Context, client *ws.Client, ms
 	atomic.AddInt64(&r.metrics.MessagesPublished, 1)
 
 	// Update presence — publishing counts as a heartbeat.
-	r.presence.Heartbeat(ctx, msg.Channel, client.UserID, r.resolveTTL(client, msg.Channel))
+	ttl := r.resolveTTL(client, msg.Channel)
+	r.presence.Heartbeat(ctx, msg.Channel, client.UserID, ttl)
+	if r.hasMetadata(client, msg.Channel) {
+		r.presence.RefreshMetadata(ctx, msg.Channel, client.UserID, ttl)
+	}
 }
 
 // resolveTTL returns the per-channel TTL override for client, falling back to the server default.
@@ -177,6 +207,23 @@ func (r *DefaultRouter) resolveTTL(client *ws.Client, channel string) time.Durat
 	return r.defaultTTL
 }
 
+// hasMetadata reports whether client has stored metadata for channel.
+func (r *DefaultRouter) hasMetadata(client *ws.Client, channel string) bool {
+	if m, ok := r.clientChannelMetadata[client]; ok {
+		_, ok := m[channel]
+		return ok
+	}
+	return false
+}
+
+// metadataOrEmpty returns meta if non-nil, otherwise an empty JSON object.
+func metadataOrEmpty(meta json.RawMessage) json.RawMessage {
+	if meta != nil {
+		return meta
+	}
+	return json.RawMessage(`{}`)
+}
+
 // updatePresence is called on core.TypePing to extend TTL of all current channels.
 func (r *DefaultRouter) updatePresence(ctx context.Context, client *ws.Client) {
 	r.mu.RLock()
@@ -184,7 +231,11 @@ func (r *DefaultRouter) updatePresence(ctx context.Context, client *ws.Client) {
 
 	for channel, clients := range r.subscriptions {
 		if _, ok := clients[client]; ok {
-			r.presence.Heartbeat(ctx, channel, client.UserID, r.resolveTTL(client, channel))
+			ttl := r.resolveTTL(client, channel)
+			r.presence.Heartbeat(ctx, channel, client.UserID, ttl)
+			if r.hasMetadata(client, channel) {
+				r.presence.RefreshMetadata(ctx, channel, client.UserID, ttl)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Clients can now attach an opaque JSON metadata object (avatar, display name, cursor colour, etc.) to their presence entry at subscribe time. Metadata is stored in Redis, forwarded in `presence.joined` events, and returned by the `/api/presence` endpoint.

## Protocol

```json
{ "type": "subscribe", "channel": "live-canvas", "metadata": { "name": "Alice", "color": "#e74c3c" } }
```

- Metadata > 2 KB → `error` envelope sent; subscription still proceeds without metadata
- `payload` is opaque to Orbit — any valid JSON object is accepted

## Storage

```
Key:  orbit:presence:meta:<channel>:<userID>
Type: Redis String (raw JSON blob)
TTL:  2 × presence TTL  (same lifecycle as the sorted-set entry)
```

## Events

**presence.joined** now includes metadata:
```json
{ "type": "message", "event": "presence.joined", "payload": { "user": "user_alice", "metadata": { "name": "Alice" } } }
```

**presence.left** is unchanged (user only).

## API

`GET /api/presence?channel=live-canvas` response shape updated:
```json
{ "channel": "live-canvas", "users": [ { "user": "user_alice", "metadata": { "name": "Alice" } } ] }
```
Users without metadata get `"metadata": {}`.

## Lifecycle

- TTL refreshed on subscribe, publish, and ping
- Key deleted immediately on disconnect

## Files changed

| File | Change |
|---|---|
| `internal/core/message.go` | `Metadata json.RawMessage` field on `Envelope` |
| `internal/presence/tracker.go` | `SetMetadata`, `RefreshMetadata`, `RemoveMetadata`, `GetUsersWithMetadata`, `PresenceEntry` type |
| `internal/router/router.go` | `clientChannelMetadata` map; validate/store on subscribe; refresh on publish/ping; remove on disconnect; `metadataOrEmpty` helper |
| `cmd/server/main.go` | `/api/presence` uses `GetUsersWithMetadata` |

Closes #25